### PR TITLE
Add initial ECS cluster Terraform module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Azavea Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# terraform-aws-ecs-cluster
+
+A Terraform module to create an Amazon Web Services (AWS) EC2 Container Service (ECS) cluster.
+
+## Usage
+
+```hcl
+data "template_file" "container_instance_cloud_config" {
+  template = "${file("cloud-config/container-instance.yml.tpl")}"
+ 
+  vars {
+    environment = "${var.environment}"
+  }
+}
+
+module "container_service_cluster" {
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.1.0"
+
+  vpc_id        = "vpc-20f74844"
+  ami_id        = "ami-b2df2ca4"
+  instance_type = "t2.micro"
+  key_name      = "hector"
+  cloud_config  = "${data.template_file.container_instance_cloud_config.rendered}"
+
+  health_check_grace_period = "600"
+  desired_capacity          = "1"
+  min_size                  = "0"
+  max_size                  = "1"
+
+  enabled_metrics = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+
+  private_subnet_ids = [...]
+
+  project     = "Something"
+  environment = "Staging"
+}
+```
+
+## Variables
+
+- `vpc_id` - ID of VPC meant to house cluster
+- `ami_id` - Cluster instance Amazon Machine Image (AMI) ID
+- `instance_type` - Instance type for cluster instances (default: `t2.micro`)
+- `key_name` - EC2 Key pair name
+- `cloud_config` - `cloud-config` user data supplied to launch configuration for cluster nodes
+- `health_check_grace_period` - Time in seconds after container instance comes into service before checking health (default: `600`)
+- `desired_capacity` - Number of EC2 instances that should be running in cluster (default: `1`)
+- `min_size` - Minimum number of EC2 instances in cluster (default: `0`)
+- `max_size` - Maximum number of EC2 instances in cluster (default: `1`)
+- `enabled_metrics` - A list of metrics to gather for the cluster
+- `private_subnet_ids` - A list of private subnet IDs to launch cluster instances
+- `scale_up_cooldown_seconds` - Number of seconds before allowing another scale up activity (default: `300`)
+- `scale_down_cooldown_seconds` - Number of seconds before allowing another scale down activity (default: `300`)
+- `high_cpu_evaluation_periods` - Number of evaluation periods for high CPU alarm (default: `2`)
+- `high_cpu_period_seconds` - Number of seconds in an evaluation period for high CPU alarm (default: `300`)
+- `high_cpu_threshold_percent` - Threshold as a percentage for high CPU alarm (default: `90`)
+- `low_cpu_evaluation_periods` - Number of evaluation periods for low CPU alarm (default: `2`)
+- `low_cpu_period_seconds` - Number of seconds in an evaluation period for low CPU alarm (default: `300`)
+- `low_cpu_threshold_percent` - Threshold as a percentage for low CPU alarm (default: `10`)
+- `high_memory_evaluation_periods` - Number of evaluation periods for high memory alarm (default: `2`)
+- `high_memory_period_seconds` - Number of seconds in an evaluation period for high memory alarm (default: `300`)
+- `high_memory_threshold_percent` - Threshold as a percentage for high memory alarm (default: `90`)
+- `low_memory_evaluation_periods` - Number of evaluation periods for low memory alarm (default: `2`)
+- `low_memory_period_seconds` - Number of seconds in an evaluation period for low memory alarm (default: `300`)
+- `low_memory_threshold_percent` - Threshold as a percentage for low memory alarm (default: `10`)
+- `project` - Name of project this cluster is for (default: `Unknown`)
+- `environment` - Name of environment this cluster is targeting (default: `Unknown`)
+
+## Outputs
+
+- `id` - The container service cluster ID
+- `name` - The container service cluster name
+- `container_instance_security_group_id` - Security group ID of the EC2 container instances
+- `container_instance_ecs_for_ec2_service_role` - Name of IAM role associated with EC2 container instances

--- a/cloud-config/base-container-instance.yml.tpl
+++ b/cloud-config/base-container-instance.yml.tpl
@@ -1,0 +1,5 @@
+#cloud-config
+
+bootcmd:
+  - mkdir -p /etc/ecs
+  - echo 'ECS_CLUSTER=${ecs_cluster_name}' >> /etc/ecs/ecs.config

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,217 @@
+#
+# IAM resources
+#
+data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "container_instance_ec2" {
+  name               = "${var.environment}ContainerInstanceProfile"
+  assume_role_policy = "${data.aws_iam_policy_document.container_instance_ec2_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_service_role" {
+  role       = "${aws_iam_role.container_instance_ec2.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "container_instance" {
+  name  = "${aws_iam_role.container_instance_ec2.name}"
+  roles = ["${aws_iam_role.container_instance_ec2.name}"]
+}
+
+#
+# Security group resources
+#
+resource "aws_security_group" "container_instance" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Name        = "sgContainerInstance"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
+  }
+}
+
+#
+# AutoScaling resources
+#
+data "template_file" "container_instance_base_cloud_config" {
+  template = "${file("${path.module}/cloud-config/base-container-instance.yml.tpl")}"
+
+  vars {
+    ecs_cluster_name = "${aws_ecs_cluster.container_instance.name}"
+  }
+}
+
+data "template_cloudinit_config" "container_instance_cloud_config" {
+  gzip          = false
+  base64_encode = false
+
+  part {
+    content_type = "text/cloud-config"
+    content      = "${data.template_file.container_instance_base_cloud_config.rendered}"
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = "${var.cloud_config}"
+  }
+}
+
+resource "aws_launch_configuration" "container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
+  image_id             = "${var.ami_id}"
+  instance_type        = "${var.instance_type}"
+  key_name             = "${var.key_name}"
+  security_groups      = ["${aws_security_group.container_instance.id}"]
+  user_data            = "${data.template_cloudinit_config.container_instance_cloud_config.rendered}"
+}
+
+resource "aws_autoscaling_group" "container_instance" {
+  name                      = "asg${var.environment}ContainerInstance"
+  launch_configuration      = "${aws_launch_configuration.container_instance.name}"
+  health_check_grace_period = "${var.health_check_grace_period}"
+  health_check_type         = "EC2"
+  desired_capacity          = "${var.desired_capacity}"
+  termination_policies      = ["OldestLaunchConfiguration", "Default"]
+  min_size                  = "${var.min_size}"
+  max_size                  = "${var.max_size}"
+  enabled_metrics           = ["${var.enabled_metrics}"]
+  vpc_zone_identifier       = ["${var.private_subnet_ids}"]
+
+  tag {
+    key                 = "Name"
+    value               = "ContainerInstance"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Project"
+    value               = "${var.project}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.environment}"
+    propagate_at_launch = true
+  }
+}
+
+#
+# ECS resources
+#
+resource "aws_ecs_cluster" "container_instance" {
+  name = "ecs${var.environment}Cluster"
+}
+
+#
+# CloudWatch resources
+#
+resource "aws_autoscaling_policy" "container_instance_scale_up" {
+  name                   = "asgScalingPolicy${var.environment}ClusterScaleUp"
+  scaling_adjustment     = 1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.scale_up_cooldown_seconds}"
+  autoscaling_group_name = "${aws_autoscaling_group.container_instance.name}"
+}
+
+resource "aws_autoscaling_policy" "container_instance_scale_down" {
+  name                   = "asgScalingPolicy${var.environment}ClusterScaleDown"
+  scaling_adjustment     = -1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = "${var.scale_down_cooldown_seconds}"
+  autoscaling_group_name = "${aws_autoscaling_group.container_instance.name}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "container_instance_high_cpu" {
+  alarm_name          = "alarm${var.environment}ClusterCPUReservationHigh"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "${var.high_cpu_evaluation_periods}"
+  metric_name         = "CPUReservation"
+  namespace           = "AWS/ECS"
+  period              = "${var.high_cpu_period_seconds}"
+  statistic           = "Maximum"
+  threshold           = "${var.high_cpu_threshold_percent}"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.container_instance.name}"
+  }
+
+  alarm_description = "Scale up if CPUReservation is above 90% for 10 minutes"
+  alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_up.arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "container_instance_low_cpu" {
+  alarm_name          = "alarm${var.environment}ClusterCPUReservationLow"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "${var.low_cpu_evaluation_periods}"
+  metric_name         = "CPUReservation"
+  namespace           = "AWS/ECS"
+  period              = "${var.low_cpu_period_seconds}"
+  statistic           = "Maximum"
+  threshold           = "${var.low_cpu_threshold_percent}"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.container_instance.name}"
+  }
+
+  alarm_description = "Scale down if the CPUReservation is below 10% for 10 minutes"
+  alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_down.arn}"]
+
+  depends_on = ["aws_cloudwatch_metric_alarm.container_instance_high_cpu"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "container_instance_high_memory" {
+  alarm_name          = "alarm${var.environment}ClusterMemoryReservationHigh"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "${var.high_memory_evaluation_periods}"
+  metric_name         = "MemoryReservation"
+  namespace           = "AWS/ECS"
+  period              = "${var.high_memory_period_seconds}"
+  statistic           = "Maximum"
+  threshold           = "${var.high_memory_threshold_percent}"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.container_instance.name}"
+  }
+
+  alarm_description = "Scale up if the MemoryReservation is above 90% for 10 minutes"
+  alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_up.arn}"]
+
+  depends_on = ["aws_cloudwatch_metric_alarm.container_instance_low_cpu"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "container_instance_low_memory" {
+  alarm_name          = "alarm${var.environment}ClusterMemoryReservationLow"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "${var.low_memory_evaluation_periods}"
+  metric_name         = "MemoryReservation"
+  namespace           = "AWS/ECS"
+  period              = "${var.low_memory_period_seconds}"
+  statistic           = "Maximum"
+  threshold           = "${var.low_memory_threshold_percent}"
+
+  dimensions {
+    ClusterName = "${aws_ecs_cluster.container_instance.name}"
+  }
+
+  alarm_description = "Scale down if the MemoryReservation is below 10% for 10 minutes"
+  alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_down.arn}"]
+
+  depends_on = ["aws_cloudwatch_metric_alarm.container_instance_high_memory"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,15 @@
+output "id" {
+  value = "${aws_ecs_cluster.container_instance.id}"
+}
+
+output "name" {
+  value = "${aws_ecs_cluster.container_instance.name}"
+}
+
+output "container_instance_security_group_id" {
+  value = "${aws_security_group.container_instance.id}"
+}
+
+output "container_instance_ecs_for_ec2_service_role" {
+  value = "${aws_iam_role.container_instance_ec2.name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,110 @@
+variable "project" {
+  default = "Unknown"
+}
+
+variable "environment" {
+  default = "Unknown"
+}
+
+variable "vpc_id" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {
+  default = "t2.micro"
+}
+
+variable "key_name" {}
+
+variable "cloud_config" {}
+
+variable "health_check_grace_period" {
+  default = "600"
+}
+
+variable "desired_capacity" {
+  default = "1"
+}
+
+variable "min_size" {
+  default = "1"
+}
+
+variable "max_size" {
+  default = "1"
+}
+
+variable "enabled_metrics" {
+  default = [
+    "GroupMinSize",
+    "GroupMaxSize",
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+
+  type = "list"
+}
+
+variable "private_subnet_ids" {
+  type = "list"
+}
+
+variable "scale_up_cooldown_seconds" {
+  default = "300"
+}
+
+variable "scale_down_cooldown_seconds" {
+  default = "300"
+}
+
+variable "high_cpu_evaluation_periods" {
+  default = "2"
+}
+
+variable "high_cpu_period_seconds" {
+  default = "300"
+}
+
+variable "high_cpu_threshold_percent" {
+  default = "90"
+}
+
+variable "low_cpu_evaluation_periods" {
+  default = "2"
+}
+
+variable "low_cpu_period_seconds" {
+  default = "300"
+}
+
+variable "low_cpu_threshold_percent" {
+  default = "10"
+}
+
+variable "high_memory_evaluation_periods" {
+  default = "2"
+}
+
+variable "high_memory_period_seconds" {
+  default = "300"
+}
+
+variable "high_memory_threshold_percent" {
+  default = "90"
+}
+
+variable "low_memory_evaluation_periods" {
+  default = "2"
+}
+
+variable "low_memory_period_seconds" {
+  default = "300"
+}
+
+variable "low_memory_threshold_percent" {
+  default = "10"
+}


### PR DESCRIPTION
Use Terraform configuration to define all of the AWS resources needed to support an Amazon ECS cluster. This includes:

- IAM roles for cluster instances
- Skeleton security groups for the cluster instances
- An Auto Scaling group of cluster instances
- Auto Scaling policies to support scaling up and down based on CPU and memory reservation

---

**Testing**

A test of this module should be done as part of the testing for https://github.com/azavea/collab-for-children/pull/36.