### PR TITLE
Fix deprecation warning with IAM instance profile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ resource "aws_iam_role_policy_attachment" "ec2_service_role" {
 }
 
 resource "aws_iam_instance_profile" "container_instance" {
-  name  = "${aws_iam_role.container_instance_ec2.name}"
-  roles = ["${aws_iam_role.container_instance_ec2.name}"]
+  name = "${aws_iam_role.container_instance_ec2.name}"
+  role = "${aws_iam_role.container_instance_ec2.name}"
 }
 
 #


### PR DESCRIPTION
Instance profiles can only be associated with a single role. Here, the `roles` attribute of `aws_iam_instance_profile` was updated to `role`.

See: https://github.com/hashicorp/terraform/pull/13130