### PR TITLE
Add support for customizing launch config root_block_device

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ module "container_service_cluster" {
   key_name      = "hector"
   cloud_config  = "${data.template_file.container_instance_cloud_config.rendered}"
 
+  root_block_device_type = "gp2"
+  root_block_device_size = "10
+
   health_check_grace_period = "600"
   desired_capacity          = "1"
   min_size                  = "0"
@@ -49,6 +52,8 @@ module "container_service_cluster" {
 
 - `vpc_id` - ID of VPC meant to house cluster
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID
+- `root_block_device_type` - Instance root block device type (default: `gp2`)
+- `root_block_device_size` - Instance root block device size in gigabytes (default: `8`)
 - `instance_type` - Instance type for cluster instances (default: `t2.micro`)
 - `key_name` - EC2 Key pair name
 - `cloud_config` - `cloud-config` user data supplied to launch configuration for cluster nodes

--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "aws_cloudwatch_metric_alarm" "container_instance_high_cpu" {
     ClusterName = "${aws_ecs_cluster.container_instance.name}"
   }
 
-  alarm_description = "Scale up if CPUReservation is above 90% for 10 minutes"
+  alarm_description = "Scale up if CPUReservation is above N% for N duration"
   alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_up.arn}"]
 }
 
@@ -175,7 +175,7 @@ resource "aws_cloudwatch_metric_alarm" "container_instance_low_cpu" {
     ClusterName = "${aws_ecs_cluster.container_instance.name}"
   }
 
-  alarm_description = "Scale down if the CPUReservation is below 10% for 10 minutes"
+  alarm_description = "Scale down if the CPUReservation is below N% for N duration"
   alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_down.arn}"]
 
   depends_on = ["aws_cloudwatch_metric_alarm.container_instance_high_cpu"]
@@ -195,7 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "container_instance_high_memory" {
     ClusterName = "${aws_ecs_cluster.container_instance.name}"
   }
 
-  alarm_description = "Scale up if the MemoryReservation is above 90% for 10 minutes"
+  alarm_description = "Scale up if the MemoryReservation is above N% for N duration"
   alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_up.arn}"]
 
   depends_on = ["aws_cloudwatch_metric_alarm.container_instance_low_cpu"]
@@ -215,7 +215,7 @@ resource "aws_cloudwatch_metric_alarm" "container_instance_low_memory" {
     ClusterName = "${aws_ecs_cluster.container_instance.name}"
   }
 
-  alarm_description = "Scale down if the MemoryReservation is below 10% for 10 minutes"
+  alarm_description = "Scale down if the MemoryReservation is below N% for N duration"
   alarm_actions     = ["${aws_autoscaling_policy.container_instance_scale_down.arn}"]
 
   depends_on = ["aws_cloudwatch_metric_alarm.container_instance_high_memory"]

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,11 @@ resource "aws_launch_configuration" "container_instance" {
     create_before_destroy = true
   }
 
+  root_block_device {
+    volume_type = "${var.root_block_device_type}"
+    volume_size = "${var.root_block_device_size}"
+  }
+
   iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
   image_id             = "${var.ami_id}"
   instance_type        = "${var.instance_type}"

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,14 @@ variable "vpc_id" {}
 
 variable "ami_id" {}
 
+variable "root_block_device_type" {
+  default = "gp2"
+}
+
+variable "root_block_device_size" {
+  default = "8"
+}
+
 variable "instance_type" {
   default = "t2.micro"
 }


### PR DESCRIPTION
Provides support for the two `root_block_device` parameters (`volume_type` and `volume_size`). These parameters allow users to define a launch configuration with a custom EBS volume type and size. Defaults align with the defaults in practice.

Fixes #3 

---

**Testing**

Use https://github.com/azavea/raster-foundry-deployment/pull/57 for testing.