### PR TITLE
Add IAM roles for ECS services, add as outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,8 @@ module "container_service_cluster" {
 - `id` - The container service cluster ID
 - `name` - The container service cluster name
 - `container_instance_security_group_id` - Security group ID of the EC2 container instances
-- `container_instance_ecs_for_ec2_service_role` - Name of IAM role associated with EC2 container instances
+- `container_instance_ecs_for_ec2_service_role_name` - Name of IAM role associated with EC2 container instances
+- `ecs_service_role_name` - Name of IAM role for use with ECS services
+- `ecs_autoscale_role_name` - Name of IAM role for use with ECS service autoscaling
+- `ecs_service_role_arn` - ARN of IAM role for use with ECS services
+- `ecs_autoscale_role_arn` - ARN of IAM role for use with ECS service autoscaling

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 #
-# IAM resources
+# Container Instance IAM resources
 #
 data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
   statement {
@@ -27,6 +27,56 @@ resource "aws_iam_role_policy_attachment" "ec2_service_role" {
 resource "aws_iam_instance_profile" "container_instance" {
   name = "${aws_iam_role.container_instance_ec2.name}"
   role = "${aws_iam_role.container_instance_ec2.name}"
+}
+
+#
+# ECS Service IAM permissions
+#
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_service_role" {
+  name               = "ecs${var.environment}ServiceRole"
+  assume_role_policy = "${data.aws_iam_policy_document.ecs_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_service_role" {
+  role       = "${aws_iam_role.ecs_service_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+}
+
+data "aws_iam_policy_document" "ecs_autoscale_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["application-autoscaling.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "ecs_autoscale_role" {
+  name               = "ecs${var.environment}AutoscaleRole"
+  assume_role_policy = "${data.aws_iam_policy_document.ecs_autoscale_assume_role.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_service_autoscaling_role" {
+  role       = "${aws_iam_role.ecs_autoscale_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
 }
 
 #

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,22 @@ output "container_instance_security_group_id" {
   value = "${aws_security_group.container_instance.id}"
 }
 
-output "container_instance_ecs_for_ec2_service_role" {
+output "container_instance_ecs_for_ec2_service_role_name" {
   value = "${aws_iam_role.container_instance_ec2.name}"
+}
+
+output "ecs_service_role_name" {
+  value = "${aws_iam_role.ecs_service_role.name}"
+}
+
+output "ecs_autoscale_role_name" {
+  value = "${aws_iam_role.ecs_autoscale_role.name}"
+}
+
+output "ecs_service_role_arn" {
+  value = "${aws_iam_role.ecs_service_role.arn}"
+}
+
+output "ecs_autoscale_role_arn" {
+  value = "${aws_iam_role.ecs_autoscale_role.arn}"
 }


### PR DESCRIPTION
# Overview

Create Service and Autoscaling IAM roles for use by ECS services launched into the cluster. When used in conjunction with the `terraform-aws-ecs-web-service` module, services launched into the same cluster will be able to use the existing IAM role instead of creating their own.

# Testing
Connects azavea/terraform-aws-ecs-web-service#3
See geotrellis/geotrellis-site-deployment#17
