### PR TITLE
Add launch config prefix; create_before_destroy lifecycle to ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,7 @@ resource "aws_launch_configuration" "container_instance" {
     volume_size = "${var.root_block_device_size}"
   }
 
+  name_prefix          = "lc${var.environment}ContainerInstance-"
   iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
   image_id             = "${var.ami_id}"
   instance_type        = "${var.instance_type}"
@@ -137,6 +138,10 @@ resource "aws_launch_configuration" "container_instance" {
 }
 
 resource "aws_autoscaling_group" "container_instance" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
   name                      = "asg${var.environment}ContainerInstance"
   launch_configuration      = "${aws_launch_configuration.container_instance.name}"
   health_check_grace_period = "${var.health_check_grace_period}"


### PR DESCRIPTION
Add a `name_prefix` to container instance launch configuration so that it is more human-readable. Also, add a `create_before_destroy` lifecycle hook to the associated ASG so that it waits for a new ASG to exist before removing the previous.

Resolves https://github.com/azavea/terraform-aws-ecs-cluster/issues/7

---

**Testing**

This change was deployed to the RF staging environment, where it applied cleanly and named the resources appropriately (ignore the missing `-`, I added that afterwards because I thought it would look better than it does in the screenshot without a `-`).

<img width="719" alt="screen shot 2017-10-12 at 14 30 41" src="https://user-images.githubusercontent.com/43639/31512719-f5e96460-af59-11e7-9674-a9e52152b42f.png">
