### PR TITLE
Output ARN for Container instance service role

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ module "container_service_cluster" {
 - `ecs_autoscale_role_name` - Name of IAM role for use with ECS service autoscaling
 - `ecs_service_role_arn` - ARN of IAM role for use with ECS services
 - `ecs_autoscale_role_arn` - ARN of IAM role for use with ECS service autoscaling
+- `container_instance_ecs_for_ec2_service_role_arn` - ARN of IAM role associated with EC2 container instances

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,3 +29,7 @@ output "ecs_service_role_arn" {
 output "ecs_autoscale_role_arn" {
   value = "${aws_iam_role.ecs_autoscale_role.arn}"
 }
+
+output "container_instance_ecs_for_ec2_service_role_arn" {
+  value = "${aws_iam_role.container_instance_ec2.arn}"
+}


### PR DESCRIPTION
Allows us to reference the container instance service role ARN without having to use the `aws_iam_role` datasource

# Testing
See azavea/raster-foundry-deployment#94