### PR TITLE
Replace auto scaling group resource by equivalent cloudformation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 A Terraform module to create an Amazon Web Services (AWS) EC2 Container Service (ECS) cluster.
 
+This module leverages CloudFormation stacks to ease maintenance on the cluster instances.
+For more details about rolling update see "AutoScalingRollingUpdate Policy" in http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html.
+
 ## Usage
 
 ```hcl
 data "template_file" "container_instance_cloud_config" {
   template = "${file("cloud-config/container-instance.yml.tpl")}"
- 
+
   vars {
     environment = "${var.environment}"
   }
@@ -63,6 +66,10 @@ module "container_service_cluster" {
 - `desired_capacity` - Number of EC2 instances that should be running in cluster (default: `1`)
 - `min_size` - Minimum number of EC2 instances in cluster (default: `0`)
 - `max_size` - Maximum number of EC2 instances in cluster (default: `1`)
+- `termination_policies` - Policies to use when deciding which instance to terminate (default: `["OldestLaunchConfiguration", "Default"]`)
+- `rolling_update_max_batch_size` - Max number of instances to update at the same time (default: `1`)
+- `rolling_update_pause_time` - How much time to wait between updating instances (default: `PT5M` - 5 minutes)
+- `rolling_update_wait_on_signal` - Should rolling update wait for a signal sent from each new instance before moving on to the next
 - `enabled_metrics` - A list of metrics to gather for the cluster
 - `private_subnet_ids` - A list of private subnet IDs to launch cluster instances
 - `scale_up_cooldown_seconds` - Number of seconds before allowing another scale up activity (default: `300`)

--- a/main.tf
+++ b/main.tf
@@ -181,39 +181,71 @@ resource "aws_launch_configuration" "container_instance" {
   user_data       = "${data.template_cloudinit_config.container_instance_cloud_config.rendered}"
 }
 
-resource "aws_autoscaling_group" "container_instance" {
+# In-depth discussion on the rolling update mechanism found in: https://github.com/hashicorp/terraform/issues/1552#issuecomment-191847434
+# AWS docuemntation here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html
+resource "aws_cloudformation_stack" "autoscaling_group" {
   lifecycle {
     create_before_destroy = true
   }
 
-  name                      = "asg${title(var.environment)}ContainerInstance"
-  launch_configuration      = "${aws_launch_configuration.container_instance.name}"
-  health_check_grace_period = "${var.health_check_grace_period}"
-  health_check_type         = "EC2"
-  desired_capacity          = "${var.desired_capacity}"
-  termination_policies      = ["OldestLaunchConfiguration", "Default"]
-  min_size                  = "${var.min_size}"
-  max_size                  = "${var.max_size}"
-  enabled_metrics           = ["${var.enabled_metrics}"]
-  vpc_zone_identifier       = ["${var.private_subnet_ids}"]
+  name = "cfStackAsg${title(var.environment)}ContainerInstance"
 
-  tag {
-    key                 = "Name"
-    value               = "ContainerInstance"
-    propagate_at_launch = true
+  template_body = <<EOF
+{
+  "Resources": {
+    "asg${title(var.environment)}ContainerInstance": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "LaunchConfigurationName": "${aws_launch_configuration.container_instance.name}",
+        "HealthCheckGracePeriod": "${var.health_check_grace_period}",
+        "HealthCheckType": "EC2",
+        "DesiredCapacity": "${var.desired_capacity}",
+        "TerminationPolicies": ["${join("\",\"", var.termination_policies)}"],
+        "MaxSize": "${var.max_size}",
+        "MinSize": "${var.min_size}",
+        "VPCZoneIdentifier": ["${join("\",\"", var.private_subnet_ids)}"],
+        "MetricsCollection": [
+            {
+                "Granularity" : "1Minute",
+                "Metrics" : ["${join("\",\"", var.enabled_metrics)}"]
+            }
+        ],
+        "Tags": [
+            {
+               "Key" : "Name",
+               "Value" : "ContainerInstance",
+               "PropagateAtLaunch" : true
+            },
+            {
+               "Key" : "Project",
+               "Value" : "${var.project}",
+               "PropagateAtLaunch" : true
+            },
+            {
+               "Key" : "Environment",
+               "Value" : "${var.environment}",
+               "PropagateAtLaunch" : true
+            }
+        ]
+      },
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MinInstancesInService": "${var.min_size}",
+          "MaxBatchSize": "${var.rolling_update_max_batch_size}",
+          "WaitOnResourceSignals": "${var.rolling_update_wait_on_signal ? "true" : "false"}",
+          "PauseTime": "${var.rolling_update_pause_time}"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "name": {
+      "Description": "The name of the auto scaling group",
+       "Value": {"Ref": "asg${title(var.environment)}ContainerInstance"}
+    }
   }
-
-  tag {
-    key                 = "Project"
-    value               = "${var.project}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "Environment"
-    value               = "${var.environment}"
-    propagate_at_launch = true
-  }
+}
+EOF
 }
 
 #
@@ -231,7 +263,7 @@ resource "aws_autoscaling_policy" "container_instance_scale_up" {
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   cooldown               = "${var.scale_up_cooldown_seconds}"
-  autoscaling_group_name = "${aws_autoscaling_group.container_instance.name}"
+  autoscaling_group_name = "${aws_cloudformation_stack.autoscaling_group.outputs["name"]}"
 }
 
 resource "aws_autoscaling_policy" "container_instance_scale_down" {
@@ -239,7 +271,7 @@ resource "aws_autoscaling_policy" "container_instance_scale_down" {
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   cooldown               = "${var.scale_down_cooldown_seconds}"
-  autoscaling_group_name = "${aws_autoscaling_group.container_instance.name}"
+  autoscaling_group_name = "${aws_cloudformation_stack.autoscaling_group.outputs["name"]}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "container_instance_high_cpu" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,22 @@ variable "environment" {
 
 variable "vpc_id" {}
 
+variable "termination_policies" {
+  default = ["OldestLaunchConfiguration", "Default"]
+}
+
+variable "rolling_update_max_batch_size" {
+  default = 1
+}
+
+variable "rolling_update_pause_time" {
+  default = "PT5M"
+}
+
+variable "rolling_update_wait_on_signal" {
+  default = false
+}
+
 variable "ami_id" {
   default = "ami-6944c513"
 }


### PR DESCRIPTION
This PR replaces the auto scaling group resource by a cloud formation stack resource that creates an equivalent auto scaling group. The cloud formation stack provides extra orchestration abilities when the auto scaling group needs to change, in the form of update policies. The chosen policy is auto scaling rolling update and that triggers a controlled update of instance batches when, for instance, a new AMI is set in the launch configuration. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html for the documentation of update policies.

This alone is not yet enough to have zero downtime deployments but it's a step in that direction. The piece of automation that is missing is to trigger container instance draining state before an instance is terminated (as part of the rolling update process). I will work on that next, following the approach described here https://aws.amazon.com/de/blogs/compute/how-to-automate-container-instance-draining-in-amazon-ecs/.
I'll make a generic and open-source lambda function to drain the container instances as part of the auto scaling lifecycle, and make a new PR to this module to integrate that.

When applying a plan with a changed launch configuration (e.g. changed AMI) terraform will wait until the update of all instances is complete. If anything fails in the update process, the cloud formation stack will automatically rollback the update, printing a message like this:
```
Error: Error applying plan:

1 error(s) occurred:

* module.ecs_cluster.module.container_service_cluster.aws_cloudformation_stack.autoscaling_group: 1 error(s) occurred:

* aws_cloudformation_stack.autoscaling_group: UPDATE_ROLLBACK_COMPLETE: ["Received 0 SUCCESS signal(s) out of 1.  Unable to satisfy 100% MinSuccessfulInstancesPercent requirement"]

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```