### PR TITLE
Use owners instead of owner-alias filter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,11 +146,8 @@ data "aws_ami" "ecs_ami" {
 data "aws_ami" "user_ami" {
   count       = "${var.lookup_latest_ami ? 0 : 1}"
   most_recent = true
+  owners      = ["${var.ami_owners}"]
 
-  filter {
-    name   = "owner-alias"
-    values = ["${var.ami_owners}"]
-  }
 
   filter {
     name   = "image-id"

--- a/main.tf
+++ b/main.tf
@@ -144,10 +144,8 @@ data "aws_ami" "ecs_ami" {
 }
 
 data "aws_ami" "user_ami" {
-  count       = "${var.lookup_latest_ami ? 0 : 1}"
-  most_recent = true
-  owners      = ["${var.ami_owners}"]
-
+  count  = "${var.lookup_latest_ami ? 0 : 1}"
+  owners = ["${var.ami_owners}"]
 
   filter {
     name   = "image-id"


### PR DESCRIPTION
# Overview
Currently, `data.aws_ami.user_ami` includes the `owner-alias` filter as a way to validate AMI ownership. We pass `self` as a value to `owner-alias`, which is an invalid value that causes the data source to return no results. We should use the `owners` filter instead, which includes `self` as an allowed value. See the terraform doumentation for [`aws_ami`](https://www.terraform.io/docs/providers/aws/d/ami.html#owners) for more information.

# Testing

I created `ami-9fe781e5`, a copy of the ECS ami, in the GeoTrellis AWS account. Then, in https://github.com/geotrellis/geotrellis-site-deployment, I ran `scripts/infra plan` with the following diff:

```diff
diff --git a/terraform/container_service.tf b/terraform/container_service.tf
index b2735f9..cdedbc4 100644
--- a/terraform/container_service.tf
+++ b/terraform/container_service.tf
@@ -10,13 +10,14 @@ data "template_file" "container_instance_cloud_config" {
 }
 
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.4.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=feature%2Ftnation%2Ffix-ami-owners"
 
   vpc_id        = "${module.vpc.id}"
-  ami_id        = "${var.aws_ecs_ami}"
+  ami_id        = "ami-9fe781e5"
   instance_type = "${var.container_instance_type}"
   key_name      = "${var.aws_key_name}"
   cloud_config  = "${data.template_file.container_instance_cloud_config.rendered}"
+  # lookup_latest_ami = true
 
   health_check_grace_period = "600"
   desired_capacity          = "${var.container_instance_asg_desired_capacity}"
```
```bash
$ ./scripts/infra plan
...
Your plan was also saved to the path below. Call the "apply" subcommand
with this plan file and Terraform will exactly execute this execution
plan.

Path: geotrellis-site-production-config-us-east-1.tfplan

~ module.container_service_cluster.aws_autoscaling_group.container_instance
    desired_capacity:     "5" => "4"
    launch_configuration: "lcProductionContainerInstance-00ee422c084a3c2c86fc1a8901" => "${aws_launch_configuration.container_instance.name}"
    max_size:             "5" => "4"

-/+ module.container_service_cluster.aws_launch_configuration.container_instance
    associate_public_ip_address:               "false" => "false"
    ebs_block_device.#:                        "0" => "<computed>"
    ebs_optimized:                             "false" => "<computed>"
    enable_monitoring:                         "true" => "true"
    iam_instance_profile:                      "ProductionContainerInstanceProfile" => "ProductionContainerInstanceProfile"
    image_id:                                  "ami-6944c513" => "ami-9fe781e5" (forces new resource)
    instance_type:                             "t2.large" => "t2.large"
    key_name:                                  "geotrellis-site" => "geotrellis-site"
    name:                                      "lcProductionContainerInstance-00ee422c084a3c2c86fc1a8901" => "<computed>"
    name_prefix:                               "lcProductionContainerInstance-" => "lcProductionContainerInstance-"
    root_block_device.#:                       "1" => "1"
    root_block_device.0.delete_on_termination: "true" => "true"
    root_block_device.0.iops:                  "0" => "<computed>"
    root_block_device.0.volume_size:           "8" => "8"
    root_block_device.0.volume_type:           "gp2" => "gp2"
    security_groups.#:                         "1" => "1"
    security_groups.2498437342:                "sg-573d7a29" => "sg-573d7a29"
    user_data:                                 "eb93fe089264621c7b69116958e42753b577a2e8" => "eb93fe089264621c7b69116958e42753b577a2e8"
```