### PR TITLE
Add name of Autoscaling Group to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ module "container_service_cluster" {
 - `ecs_service_role_arn` - ARN of IAM role for use with ECS services
 - `ecs_autoscale_role_arn` - ARN of IAM role for use with ECS service autoscaling
 - `container_instance_ecs_for_ec2_service_role_arn` - ARN of IAM role associated with EC2 container instances
+- `container_instance_autoscaling_group_name` - Name of Container Instance Autoscaling Group

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,6 +22,10 @@ output "ecs_autoscale_role_name" {
   value = "${aws_iam_role.ecs_autoscale_role.name}"
 }
 
+output "container_instance_autoscaling_group_name" {
+  value = "${aws_autoscaling_group.container_instance.name}"
+}
+
 output "ecs_service_role_arn" {
   value = "${aws_iam_role.ecs_service_role.arn}"
 }


### PR DESCRIPTION
The purpose of this PR is to add the autoscaling group name to the outputs so it can be referenced in other Terraform scripts.  For example:

```
resource "aws_autoscaling_schedule" "asgJenkinsContainerInstance-down" {
  scheduled_action_name  = "asgJenkinsContainerInstance-down"
  min_size               = 0
  max_size               = 1
  desired_capacity       = 0
  recurrence             = "30 6 * * *"
  autoscaling_group_name = "${module.ecs-cluster.container_instance_autoscaling_group_name}"
}

resource "aws_autoscaling_schedule" "asgJenkinsContainerInstance-up" {
  scheduled_action_name  = "asgJenkinsContainerInstance-up"
  min_size               = 0
  max_size               = 1
  desired_capacity       = 1
  recurrence             = "30 19 * * 0-4"
  autoscaling_group_name = "${module.ecs-cluster.container_instance_autoscaling_group_name}"
}
```