### PR TITLE
Refactor Usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ data "template_file" "container_instance_cloud_config" {
 }
 
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=0.6.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=1.1.0"
 
   vpc_id        = "vpc-20f74844"
   ami_id        = "ami-b2df2ca4"


### PR DESCRIPTION
## Overview

Refactor Usage example in README.md to bump `?ref=` to latest release version `1.1.0`.

Fixes #28 