### PR TITLE
Remove AmazonEC2ContainerServiceAutoscaleRole creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ module "container_service_cluster" {
 - `container_instance_security_group_id` - Security group ID of the EC2 container instances
 - `container_instance_ecs_for_ec2_service_role_name` - Name of IAM role associated with EC2 container instances
 - `ecs_service_role_name` - Name of IAM role for use with ECS services
-- `ecs_autoscale_role_name` - Name of IAM role for use with ECS service autoscaling
 - `ecs_service_role_arn` - ARN of IAM role for use with ECS services
-- `ecs_autoscale_role_arn` - ARN of IAM role for use with ECS service autoscaling
 - `container_instance_ecs_for_ec2_service_role_arn` - ARN of IAM role associated with EC2 container instances
 - `container_instance_autoscaling_group_name` - Name of container instance Autoscaling Group

--- a/main.tf
+++ b/main.tf
@@ -69,14 +69,8 @@ data "aws_iam_policy_document" "ecs_autoscale_assume_role" {
   }
 }
 
-resource "aws_iam_role" "ecs_autoscale_role" {
-  name               = "ecs${title(var.environment)}AutoscaleRole"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs_autoscale_assume_role.json}"
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_service_autoscaling_role" {
-  role       = "${aws_iam_role.ecs_autoscale_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole"
+data "aws_iam_role" "ecs_autoscale_role" {
+  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -69,10 +69,6 @@ data "aws_iam_policy_document" "ecs_autoscale_assume_role" {
   }
 }
 
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
-}
-
 #
 # Security group resources
 #

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,20 +18,12 @@ output "ecs_service_role_name" {
   value = "${aws_iam_role.ecs_service_role.name}"
 }
 
-output "ecs_autoscale_role_name" {
-  value = "${data.aws_iam_role.ecs_autoscale_role.id}"
-}
-
 output "container_instance_autoscaling_group_name" {
   value = "${aws_autoscaling_group.container_instance.name}"
 }
 
 output "ecs_service_role_arn" {
   value = "${aws_iam_role.ecs_service_role.arn}"
-}
-
-output "ecs_autoscale_role_arn" {
-  value = "${data.aws_iam_role.ecs_autoscale_role.arn}"
 }
 
 output "container_instance_ecs_for_ec2_service_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "ecs_service_role_name" {
 }
 
 output "ecs_autoscale_role_name" {
-  value = "${aws_iam_role.ecs_autoscale_role.name}"
+  value = "${data.aws_iam_role.ecs_autoscale_role.id}"
 }
 
 output "container_instance_autoscaling_group_name" {
@@ -31,7 +31,7 @@ output "ecs_service_role_arn" {
 }
 
 output "ecs_autoscale_role_arn" {
-  value = "${aws_iam_role.ecs_autoscale_role.arn}"
+  value = "${data.aws_iam_role.ecs_autoscale_role.arn}"
 }
 
 output "container_instance_ecs_for_ec2_service_role_arn" {


### PR DESCRIPTION
## Overview

Repeal Amazon EC2ContainerServiceAutoscaleRole creation and replace with `data` reference to [service-linked](https://docs.aws.amazon.com/autoscaling/application/userguide/application-autoscaling-service-linked-roles.html) IAM role.

Fixes #24 

## Testing

I brought up a Django app using [azavea/terraform-aws-ecs-cluster](https://github.com/azavea/terraform-aws-ecs-cluster) and [azavea/terraform-aws-ecs-web-service](https://github.com/azavea/terraform-aws-ecs-web-service).

Run `terraform plan`:

```bash
Terraform will perform the following actions:

-/+ aws_ecs_task_definition.app (new resource required)
      id:                    "maiden" => <computed> (forces new resource)
      arn:                   "arn:aws:ecs:us-east-1:279682201306:task-definition/maiden:56" => <computed>
      container_definitions: "[...]" (forces new resource)
      family:                "maiden" => "maiden"
      network_mode:          "" => <computed>
      revision:              "56" => <computed>

  ~ module.app_web_service.aws_ecs_service.main
      task_definition:       "maiden:56" => "${var.task_definition_id}"


Plan: 1 to add, 1 to change, 1 to destroy.
```

AWS does not replace `aws_appautoscaling_target.role_arn`.

