### PR TITLE
Migrate to using aws_launch_template vs. aws_launch_configuration and add support for T2 Unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ module "container_service_cluster" {
 - `root_block_device_type` - Instance root block device type (default: `gp2`)
 - `root_block_device_size` - Instance root block device size in gigabytes (default: `8`)
 - `instance_type` - Instance type for cluster instances (default: `t2.micro`)
+- `unlimited_cpu` - If this variable is `true`, then the instance will be configured as T2 Unlimited. (default: `false`)
 - `key_name` - EC2 Key pair name
 - `cloud_config_content` - user data supplied to launch configuration for cluster nodes
 - `cloud_config_content_type` - the type of configuration being passed in as user data, see [EC2 user guide](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AmazonLinuxAMIBasics.html#CloudInit) for a list of possible types (default: `text/cloud-config`)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module "container_service_cluster" {
 - `root_block_device_size` - Instance root block device size in gigabytes (default: `8`)
 - `instance_type` - Instance type for cluster instances (default: `t2.micro`)
 - `unlimited_cpu` - If this variable is `true`, then the instance will be configured as T2 Unlimited. (default: `false`)
+- `detailed_monitoring` - If this variable is `true`, then [detailed monitoring](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) will be enabled on the instance. (default: `false`)
 - `key_name` - EC2 Key pair name
 - `cloud_config_content` - user data supplied to launch configuration for cluster nodes
 - `cloud_config_content_type` - the type of configuration being passed in as user data, see [EC2 user guide](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AmazonLinuxAMIBasics.html#CloudInit) for a list of possible types (default: `text/cloud-config`)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module "container_service_cluster" {
 - `root_block_device_type` - Instance root block device type (default: `gp2`)
 - `root_block_device_size` - Instance root block device size in gigabytes (default: `8`)
 - `instance_type` - Instance type for cluster instances (default: `t2.micro`)
-- `unlimited_cpu` - If this variable is `true`, then the instance will be configured as T2 Unlimited. (default: `false`)
+- `cpu_credit_specification` - Credit option for CPU usage. Can be ["standard"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-standard-mode.html) or ["unlimited"](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-unlimited-mode.html). (default: `standard`).
 - `detailed_monitoring` - If this variable is `true`, then [detailed monitoring](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) will be enabled on the instance. (default: `false`)
 - `key_name` - EC2 Key pair name
 - `cloud_config_content` - user data supplied to launch configuration for cluster nodes

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ data "aws_ami" "user_ami" {
 
 resource "aws_launch_template" "container_instance" {
   block_device_mappings {
-    device_name = "/dev/sda1"
+    device_name = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.root_device_name) : join("", data.aws_ami.user_ami.*.root_device_name)}"
 
     ebs {
       volume_type = "${var.root_block_device_type}"

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ resource "aws_launch_template" "container_instance" {
   user_data                            = "${base64encode(data.template_cloudinit_config.container_instance_cloud_config.rendered)}"
 
   monitoring {
-    enabled = true
+    enabled = "${var.detailed_monitoring}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_launch_template" "container_instance" {
   }
 
   credit_specification {
-    cpu_credits = "${var.unlimited_cpu ? "unlimited" : "standard"}"
+    cpu_credits = "${var.cpu_credit_specification}"
   }
 
   disable_api_termination = false

--- a/main.tf
+++ b/main.tf
@@ -143,27 +143,41 @@ data "aws_ami" "user_ami" {
   }
 }
 
-resource "aws_launch_configuration" "container_instance" {
-  lifecycle {
-    create_before_destroy = true
+resource "aws_launch_template" "container_instance" {
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_type = "${var.root_block_device_type}"
+      volume_size = "${var.root_block_device_size}"
+    }
   }
 
-  root_block_device {
-    volume_type = "${var.root_block_device_type}"
-    volume_size = "${var.root_block_device_size}"
+  credit_specification {
+    cpu_credits = "${var.unlimited_cpu ? "unlimited" : "standard"}"
   }
 
-  name_prefix          = "lc${title(var.environment)}ContainerInstance-"
-  iam_instance_profile = "${aws_iam_instance_profile.container_instance.name}"
+  disable_api_termination = false
+
+  name_prefix = "lt${title(var.environment)}ContainerInstance-"
+
+  iam_instance_profile {
+    name = "${aws_iam_instance_profile.container_instance.name}"
+  }
 
   # Using join() is a workaround for depending on conditional resources.
   # https://github.com/hashicorp/terraform/issues/2831#issuecomment-298751019
   image_id = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.image_id) : join("", data.aws_ami.user_ami.*.image_id)}"
 
-  instance_type   = "${var.instance_type}"
-  key_name        = "${var.key_name}"
-  security_groups = ["${aws_security_group.container_instance.id}"]
-  user_data       = "${data.template_cloudinit_config.container_instance_cloud_config.rendered}"
+  instance_initiated_shutdown_behavior = "terminate"
+  instance_type                        = "${var.instance_type}"
+  key_name                             = "${var.key_name}"
+  vpc_security_group_ids               = ["${aws_security_group.container_instance.id}"]
+  user_data                            = "${base64encode(data.template_cloudinit_config.container_instance_cloud_config.rendered)}"
+
+  monitoring {
+    enabled = true
+  }
 }
 
 resource "aws_autoscaling_group" "container_instance" {
@@ -171,8 +185,13 @@ resource "aws_autoscaling_group" "container_instance" {
     create_before_destroy = true
   }
 
-  name                      = "asg${title(var.environment)}ContainerInstance"
-  launch_configuration      = "${aws_launch_configuration.container_instance.name}"
+  name = "asg${title(var.environment)}ContainerInstance"
+
+  launch_template = {
+    id      = "${aws_launch_template.container_instance.id}"
+    version = "$$Latest"
+  }
+
   health_check_grace_period = "${var.health_check_grace_period}"
   health_check_type         = "EC2"
   desired_capacity          = "${var.desired_capacity}"

--- a/variables.tf
+++ b/variables.tf
@@ -32,8 +32,8 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
-variable "unlimited_cpu" {
-  default = false
+variable "cpu_credit_specification" {
+  default = "standard"
 }
 
 variable "detailed_monitoring" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,10 @@ variable "unlimited_cpu" {
   default = false
 }
 
+variable "detailed_monitoring" {
+  default = false
+}
+
 variable "key_name" {}
 
 variable "cloud_config_content" {}

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,10 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
+variable "unlimited_cpu" {
+  default = false
+}
+
 variable "key_name" {}
 
 variable "cloud_config_content" {}


### PR DESCRIPTION
## Overview

* Remove `aws_launch_configuration`
* Add `aws_launch_template`
* Add `unlimited_cpu` variable and update README
* Pull root device name from AMI data lookup
* Add CloudWatch `detailed_monitoring` variable

Fixes #30 and #31 

## Notes

There was an issue in testing where Terraform was throwing this:

```
* aws_autoscaling_group.container_instance: Error updating Autoscaling group: InvalidQueryParameter: Invalid launch template: When a network interface is provided, the security groups must be a part of it.
```

When I removed `ebs_optimized = true` from the resource, this error was suppressed. 

See these docs for more information on using a launch template:
 * https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg-launch-template.html
 * https://www.terraform.io/docs/providers/aws/r/launch_template.html

## Testing

I modified the Raster Foundry deployment tooling to use the version of the AWS provider that resolved https://github.com/terraform-providers/terraform-provider-aws/issues/4553, and directed it to use our changes:

```diff
diff --git a/core/terraform/config.tf b/core/terraform/config.tf
index a5b75ec..8a3c43b 100644
--- a/core/terraform/config.tf
+++ b/core/terraform/config.tf
@@ -3,7 +3,7 @@ provider "archive" {
 }

 provider "aws" {
-  version = "~> 1.21.0"
+  version = "~> 1.34.0"
   region  = "${var.aws_region}"
 }

diff --git a/core/terraform/container_service.tf b/core/terraform/container_service.tf
index 0e22775..cdc8e0e 100644
--- a/core/terraform/container_service.tf
+++ b/core/terraform/container_service.tf
@@ -15,7 +15,7 @@ data "template_file" "container_instance_cloud_config" {
 # ECS Resources
 #
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=1.1.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=c3c810600ab82d046bd90b4803854ab379aaff63"

   root_block_device_type = "${var.container_instance_root_block_device_type}"
   root_block_device_size = "${var.container_instance_root_block_device_size}"
```

Then, I cycled staging:

```bash
$ docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform
bash-4.3# ./scripts/infra plan
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  ~ aws_lambda_function.alert_batch_failures
      last_modified:                                        "2018-09-27T15:53:51.575+0000" => <computed>
      source_code_hash:                                     "V/kmJRV66sacT9jcwR+z5pFaBv9OFLwQpn7yb3R3PNE=" => "brOp6ocyQnQL4nMM/Lh0r5qXYkA6r4GGrOkwCt9x8O8="

  ~ aws_lambda_function.schedule_batch
      last_modified:                                        "2018-09-27T15:53:51.252+0000" => <computed>
      source_code_hash:                                     "zhj8xpu3tHOj3TQo+ZP+dIZ7k7sHH+G8CE7IbyCXyi8=" => "vKtMjzb3F+kdpd4xoUZOVFgvzloty5oYiOKpY8h4gF0="

  ~ module.container_service_cluster.aws_autoscaling_group.container_instance
      desired_capacity:                                     "5" => "8"
      launch_configuration:                                 "lcStagingContainerInstance-20180920184922809000000001" => ""
      launch_template.#:                                    "0" => "1"
      launch_template.0.id:                                 "" => "${aws_launch_template.container_instance.id}"
      launch_template.0.version:                            "" => "$Latest"

  - module.container_service_cluster.aws_iam_role.ecs_autoscale_role

  - module.container_service_cluster.aws_iam_role_policy_attachment.ecs_service_autoscaling_role

  - module.container_service_cluster.aws_launch_configuration.container_instance

  + module.container_service_cluster.aws_launch_template.container_instance
      id:                                                   <computed>
      block_device_mappings.#:                              "1"
      block_device_mappings.0.device_name:                  "/dev/xvda"
      block_device_mappings.0.ebs.#:                        "1"
      block_device_mappings.0.ebs.0.delete_on_termination:  "false" => ""
      block_device_mappings.0.ebs.0.encrypted:              "false" => ""
      block_device_mappings.0.ebs.0.iops:                   <computed>
      block_device_mappings.0.ebs.0.volume_size:            "32"
      block_device_mappings.0.ebs.0.volume_type:            "gp2"
      credit_specification.#:                               "1"
      credit_specification.0.cpu_credits:                   "standard"
      default_version:                                      <computed>
      disable_api_termination:                              "false"
      iam_instance_profile.#:                               "1"
      iam_instance_profile.0.name:                          "StagingContainerInstanceProfile"
      image_id:                                             "ami-0b9a214f40c38d5eb"
      instance_initiated_shutdown_behavior:                 "terminate"
      instance_type:                                        "t2.xlarge"
      key_name:                                             "raster-foundry-stg"
      latest_version:                                       <computed>
      monitoring.#:                                         "1"
      monitoring.0.enabled:                                 "false"
      name:                                                 <computed>
      name_prefix:                                          "ltStagingContainerInstance-"
      user_data:                                            "Q29udGVudC1UeXBlOiBtdWx0aXBhcnQvbWl4ZWQ7IGJvdW5kYXJ5PSJNSU1FQk9VTkRBUlkiCk1JTUUtVmVyc2lvbjogMS4wDQoNCi0tTUlNRUJPVU5EQVJZDQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiA3Yml0DQpDb250ZW50LVR5cGU6IHRleHQvY2xvdWQtY29uZmlnDQpNaW1lLVZlcnNpb246IDEuMA0KDQojY2xvdWQtY29uZmlnCgpib290Y21kOgogIC0gbWtkaXIgLXAgL2V0Yy9lY3MKICAtIGVjaG8gJ0VDU19DTFVTVEVSPWVjc1N0YWdpbmdDbHVzdGVyJyA+PiAvZXRjL2Vjcy9lY3MuY29uZmlnCg0KLS1NSU1FQk9VTkRBUlkNCkNvbnRlbnQtVHJhbnNmZXItRW5jb2Rpbmc6IDdiaXQNCkNvbnRlbnQtVHlwZTogdGV4dC9jbG91ZC1jb25maWcNCk1pbWUtVmVyc2lvbjogMS4wDQoNCiNjbG91ZC1jb25maWcKCnBhY2thZ2VzOgogLSBhd3Nsb2dzCgpydW5jbWQ6CiAgLSBjdXJsIC1vIC9ldGMvcGFwZXJ0cmFpbC1idW5kbGUucGVtIGh0dHBzOi8vcGFwZXJ0cmFpbGFwcC5jb20vdG9vbHMvcGFwZXJ0cmFpbC1idW5kbGUucGVtCgp3cml0ZV9maWxlczoKICAtIHBhdGg6IC9ldGMvYXdzbG9ncy9hd3Nsb2dzLmNvbmYKICAgIHBlcm1pc3Npb25zOiAwNjQ0CiAgICBvd25lcjogcm9vdDpyb290CiAgICBjb250ZW50OiB8CiAgICAgIFtnZW5lcmFsXQogICAgICBzdGF0ZV9maWxlID0gL3Zhci9saWIvYXdzbG9ncy9hZ2VudC1zdGF0ZQoKICAgICAgWy92YXIvbG9nL2RtZXNnXQogICAgICBmaWxlID0gL3Zhci9sb2cvZG1lc2cKICAgICAgbG9nX2dyb3VwX25hbWUgPSBsb2dTdGFnaW5nQ29udGFpbmVySW5zdGFuY2UKICAgICAgbG9nX3N0cmVhbV9uYW1lID0gZG1lc2cve2luc3RhbmNlX2lkfQoKICAgICAgWy92YXIvbG9nL21lc3NhZ2VzXQogICAgICBmaWxlID0gL3Zhci9sb2cvbWVzc2FnZXMKICAgICAgbG9nX2dyb3VwX25hbWUgPSBsb2dTdGFnaW5nQ29udGFpbmVySW5zdGFuY2UKICAgICAgbG9nX3N0cmVhbV9uYW1lID0gbWVzc2FnZXMve2luc3RhbmNlX2lkfQogICAgICBkYXRldGltZV9mb3JtYXQgPSAlYiAlZCAlSDolTTolUwoKICAgICAgWy92YXIvbG9nL2RvY2tlcl0KICAgICAgZmlsZSA9IC92YXIvbG9nL2RvY2tlcgogICAgICBsb2dfZ3JvdXBfbmFtZSA9IGxvZ1N0YWdpbmdDb250YWluZXJJbnN0YW5jZQogICAgICBsb2dfc3RyZWFtX25hbWUgPSBkb2NrZXIve2luc3RhbmNlX2lkfQogICAgICBkYXRldGltZV9mb3JtYXQgPSAlWS0lbS0lZFQlSDolTTolUy4lZgoKICAgICAgWy92YXIvbG9nL2Vjcy9lY3MtaW5pdC5sb2ddCiAgICAgIGZpbGUgPSAvdmFyL2xvZy9lY3MvZWNzLWluaXQubG9nLioKICAgICAgbG9nX2dyb3VwX25hbWUgPSBsb2dTdGFnaW5nQ29udGFpbmVySW5zdGFuY2UKICAgICAgbG9nX3N0cmVhbV9uYW1lID0gZWNzLWluaXQve2luc3RhbmNlX2lkfQogICAgICBkYXRldGltZV9mb3JtYXQgPSAlWS0lbS0lZFQlSDolTTolU1oKCiAgICAgIFsvdmFyL2xvZy9lY3MvZWNzLWFnZW50LmxvZ10KICAgICAgZmlsZSA9IC92YXIvbG9nL2Vjcy9lY3MtYWdlbnQubG9nLioKICAgICAgbG9nX2dyb3VwX25hbWUgPSBsb2dTdGFnaW5nQ29udGFpbmVySW5zdGFuY2UKICAgICAgbG9nX3N0cmVhbV9uYW1lID0gZWNzLWFnZW50L3tpbnN0YW5jZV9pZH0KICAgICAgZGF0ZXRpbWVfZm9ybWF0ID0gJVktJW0tJWRUJUg6JU06JVNaCgogIC0gcGF0aDogL2V0Yy9pbml0L2F3c2xvZ3MuY29uZgogICAgcGVybWlzc2lvbnM6IDA2NDQKICAgIG93bmVyOiByb290OnJvb3QKICAgIGNvbnRlbnQ6IHwKICAgICAgZGVzY3JpcHRpb24gIkNvbmZpZ3VyZSBhbmQgc3RhcnQgQ2xvdWRXYXRjaCBMb2dzIGFnZW50IG9uIEFtYXpvbiBFQ1MgY29udGFpbmVyIGluc3RhbmNlIgogICAgICBhdXRob3IgIkFtYXpvbiBXZWIgU2VydmljZXMiCiAgICAgIHN0YXJ0IG9uIHN0YXJ0ZWQgZWNzCgogICAgICBzY3JpcHQKICAgICAgICAgIGV4ZWMgMj4+L3Zhci9sb2cvZWNzL2Nsb3Vkd2F0Y2gtbG9ncy1zdGFydC5sb2cKICAgICAgICAgIHNldCAteAoKICAgICAgICAgIHVudGlsIGN1cmwgLXMgaHR0cDovL2xvY2FsaG9zdDo1MTY3OC92MS9tZXRhZGF0YQogICAgICAgICAgZG8KICAgICAgICAgICAgICBzbGVlcCAxCiAgICAgICAgICBkb25lCgogICAgICAgICAgc2VydmljZSBhd3Nsb2dzIHN0YXJ0CiAgICAgICAgICBjaGtjb25maWcgYXdzbG9ncyBvbgogICAgICBlbmQgc2NyaXB0CgogIC0gcGF0aDogL3Zhci9saWIvc3RhdHNkL2NvbmZpZy5qcwogICAgcGVybWlzc2lvbnM6IDA2NDQKICAgIG93bmVyOiByb290OnJvb3QKICAgIGNvbnRlbnQ6IHwKICAgICAgewogICAgICAgICAgbGlicmF0bzogewogICAgICAgICAgICAgIGVtYWlsOiAgInN5c3RlbXMrcmZAYXphdmVhLmNvbSIsCiAgICAgICAgICAgICAgdG9rZW46ICAiMGZkMTRlZDA2NTM2NmI4YWI1ZThhM2YwZmJjZDY2NzM3YTAzZjg4MTlkMTcyNmJlMTJiYzcwNjI5ZDlkODQxMyIKICAgICAgICAgIH0KICAgICAgICAgICwgYmFja2VuZHM6IFsic3RhdHNkLWxpYnJhdG8tYmFja2VuZCJdCiAgICAgICAgICAsIHBvcnQ6IDgxMjUKICAgICAgICAgICwga2V5TmFtZVNhbml0aXplOiBmYWxzZQogICAgICAgICAgLCBkZWxldGVJZGxlU3RhdHM6IHRydWUKICAgICAgfQoNCi0tTUlNRUJPVU5EQVJZLS0NCg=="
      vpc_security_group_ids.#:                             "1"
      vpc_security_group_ids.1451302940:                    "sg-18fad966"


Plan: 1 to add, 3 to change, 3 to destroy.
...
bash-4.3# ./scripts/infra apply
...
Apply complete! Resources: 1 added, 3 changed, 3 destroyed.
```
