### PR TITLE
Rename private_subnet_ids to subnet_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ module "container_service_cluster" {
     "GroupTotalInstances",
   ]
 
-  private_subnet_ids = [...]
+  subnet_ids = [...]
 
   project     = "Something"
   environment = "Staging"
@@ -91,7 +91,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 - `min_size` - Minimum number of EC2 instances in cluster (default: `0`)
 - `max_size` - Maximum number of EC2 instances in cluster (default: `1`)
 - `enabled_metrics` - A list of metrics to gather for the cluster
-- `private_subnet_ids` - A list of private subnet IDs to launch cluster instances
+- `subnet_ids` - A list of subnet IDs to launch cluster instances
 - `scale_up_cooldown_seconds` - Number of seconds before allowing another scale up activity (default: `300`)
 - `scale_down_cooldown_seconds` - Number of seconds before allowing another scale down activity (default: `300`)
 - `high_cpu_evaluation_periods` - Number of evaluation periods for high CPU alarm (default: `2`)

--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ resource "aws_autoscaling_group" "container_instance" {
   min_size                  = "${var.min_size}"
   max_size                  = "${var.max_size}"
   enabled_metrics           = ["${var.enabled_metrics}"]
-  vpc_zone_identifier       = ["${var.private_subnet_ids}"]
+  vpc_zone_identifier       = ["${var.subnet_ids}"]
 
   tag {
     key                 = "Name"

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "enabled_metrics" {
   type = "list"
 }
 
-variable "private_subnet_ids" {
+variable "subnet_ids" {
   type = "list"
 }
 


### PR DESCRIPTION
## Overview

Updates the variable naming so that it reflects that private or public subnets can be supplied to the ECS cluster configuration.

Resolves #38 

## Testing Instructions

```bash
$ terraform init && terraform validate --check-variables=false
$ echo $?
0
```
