### PR TITLE
Switch to use target tracking autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 - `subnet_ids` - A list of subnet IDs to launch cluster instances
 - `cpu_reservation_target_value` - CPUReservation metric target value for [target tracking autoscaling](https://segment.com/blog/when-aws-autoscale-doesn-t/) (default: `90.0`)
 - `memory_reservation_target_value` - MemoryReservation metric target value for target tracking autoscaling (default: `90.0`)
-- `target_tracking_autoscaling_statistic` - Statistic for target tracking autoscaling metric specification (default: `Average`)
+- `target_value_metric_statistic` - Statistic for target tracking autoscaling metric specification (default: `Average`)
 - `project` - Name of project this cluster is for (default: `Unknown`)
 - `environment` - Name of environment this cluster is targeting (default: `Unknown`)
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 - `max_size` - Maximum number of EC2 instances in cluster (default: `1`)
 - `enabled_metrics` - A list of metrics to gather for the cluster
 - `subnet_ids` - A list of subnet IDs to launch cluster instances
-- `ecs_cluster_cpu_reservation_target` - CPUReservation metric target value for [target tracking autoscaling](https://segment.com/blog/when-aws-autoscale-doesn-t/) (default: `90.0`)
-- `ecs_cluster_memory_reservation_target` - MemoryReservation metric target value for [target tracking autoscaling](https://segment.com/blog/when-aws-autoscale-doesn-t/) (default: `90.0`)
+- `cpu_reservation_target_value` - CPUReservation metric target value for [target tracking autoscaling](https://segment.com/blog/when-aws-autoscale-doesn-t/) (default: `90.0`)
+- `memory_reservation_target_value` - MemoryReservation metric target value for target tracking autoscaling (default: `90.0`)
+- `target_tracking_autoscaling_statistic` - Statistic for target tracking autoscaling metric specification (default: `Average`)
 - `project` - Name of project this cluster is for (default: `Unknown`)
 - `environment` - Name of environment this cluster is targeting (default: `Unknown`)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ data "template_file" "container_instance_cloud_config" {
 }
 
 module "container_service_cluster" {
-  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=2.0.0"
+  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=3.0.0"
 
   vpc_id        = "vpc-20f74844"
   ami_id        = "ami-b2df2ca4"
@@ -92,20 +92,8 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 - `max_size` - Maximum number of EC2 instances in cluster (default: `1`)
 - `enabled_metrics` - A list of metrics to gather for the cluster
 - `subnet_ids` - A list of subnet IDs to launch cluster instances
-- `scale_up_cooldown_seconds` - Number of seconds before allowing another scale up activity (default: `300`)
-- `scale_down_cooldown_seconds` - Number of seconds before allowing another scale down activity (default: `300`)
-- `high_cpu_evaluation_periods` - Number of evaluation periods for high CPU alarm (default: `2`)
-- `high_cpu_period_seconds` - Number of seconds in an evaluation period for high CPU alarm (default: `300`)
-- `high_cpu_threshold_percent` - Threshold as a percentage for high CPU alarm (default: `90`)
-- `low_cpu_evaluation_periods` - Number of evaluation periods for low CPU alarm (default: `2`)
-- `low_cpu_period_seconds` - Number of seconds in an evaluation period for low CPU alarm (default: `300`)
-- `low_cpu_threshold_percent` - Threshold as a percentage for low CPU alarm (default: `10`)
-- `high_memory_evaluation_periods` - Number of evaluation periods for high memory alarm (default: `2`)
-- `high_memory_period_seconds` - Number of seconds in an evaluation period for high memory alarm (default: `300`)
-- `high_memory_threshold_percent` - Threshold as a percentage for high memory alarm (default: `90`)
-- `low_memory_evaluation_periods` - Number of evaluation periods for low memory alarm (default: `2`)
-- `low_memory_period_seconds` - Number of seconds in an evaluation period for low memory alarm (default: `300`)
-- `low_memory_threshold_percent` - Threshold as a percentage for low memory alarm (default: `10`)
+- `ecs_cluster_cpu_reservation_target` - CPUReservation metric target value for [target tracking autoscaling](https://segment.com/blog/when-aws-autoscale-doesn-t/) (default: `90.0`)
+- `ecs_cluster_memory_reservation_target` - MemoryReservation metric target value for [target tracking autoscaling](https://segment.com/blog/when-aws-autoscale-doesn-t/) (default: `90.0`)
 - `project` - Name of project this cluster is for (default: `Unknown`)
 - `environment` - Name of environment this cluster is targeting (default: `Unknown`)
 

--- a/main.tf
+++ b/main.tf
@@ -229,37 +229,44 @@ resource "aws_ecs_cluster" "container_instance" {
 #
 # CloudWatch resources
 #
-resource "aws_autoscaling_policy" "container_instance" {
-  name                   = "asgScalingPolicy${title(var.environment)}Cluster"
+resource "aws_autoscaling_policy" "container_instance_cpu_reservation" {
+  name                   = "asgScalingPolicyCPUReservation${title(var.environment)}Cluster"
   autoscaling_group_name = "${aws_autoscaling_group.container_instance.name}"
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "TargetTrackingScaling"
 
   target_tracking_configuration {
     customized_metric_specification {
-      dimensions {
+      metric_dimension {
         name  = "ClusterName"
         value = "${aws_ecs_cluster.container_instance.name}"
       }
 
       metric_name = "CPUReservation"
       namespace   = "AWS/ECS"
-      statistic   = "${var.target_tracking_autoscaling_statistic}"
+      statistic   = "${var.target_value_metric_statistic}"
     }
 
     target_value = "${var.cpu_reservation_target_value}"
   }
+}
+
+resource "aws_autoscaling_policy" "container_instance_memory_reservation" {
+  name                   = "asgScalingPolicyMemoryReservation${title(var.environment)}Cluster"
+  autoscaling_group_name = "${aws_autoscaling_group.container_instance.name}"
+  adjustment_type        = "ChangeInCapacity"
+  policy_type            = "TargetTrackingScaling"
 
   target_tracking_configuration {
     customized_metric_specification {
-      dimensions {
+      metric_dimension {
         name  = "ClusterName"
         value = "${aws_ecs_cluster.container_instance.name}"
       }
 
       metric_name = "MemoryReservation"
       namespace   = "AWS/ECS"
-      statistic   = "${var.target_tracking_autoscaling_statistic}"
+      statistic   = "${var.target_value_metric_statistic}"
     }
 
     target_value = "${var.memory_reservation_target_value}"

--- a/main.tf
+++ b/main.tf
@@ -244,10 +244,10 @@ resource "aws_autoscaling_policy" "container_instance" {
 
       metric_name = "CPUReservation"
       namespace   = "AWS/ECS"
-      statistic   = "Maximum"
+      statistic   = "${var.target_tracking_autoscaling_statistic}"
     }
 
-    target_value = "${var.ecs_cluster_cpu_reservation_target}"
+    target_value = "${var.cpu_reservation_target_value}"
   }
 
   target_tracking_configuration {
@@ -259,9 +259,9 @@ resource "aws_autoscaling_policy" "container_instance" {
 
       metric_name = "MemoryReservation"
       namespace   = "AWS/ECS"
-      statistic   = "Maximum"
+      statistic   = "${var.target_tracking_autoscaling_statistic}"
     }
 
-    target_value = "${var.ecs_cluster_memory_reservation_target}"
+    target_value = "${var.memory_reservation_target_value}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -83,10 +83,6 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "target_tracking_metric_type" {
-  default = "ASGAverageCPUUtilization"
-}
-
 variable "ecs_cluster_cpu_reservation_target" {
   default = "90.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -83,10 +83,14 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "ecs_cluster_cpu_reservation_target" {
+variable "cpu_reservation_target_value" {
   default = "90.0"
 }
 
-variable "ecs_cluster_memory_reservation_target" {
+variable "memory_reservation_target_value" {
   default = "90.0"
+}
+
+variable "target_tracking_autoscaling_statistic" {
+  default = "Average"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -83,58 +83,14 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "scale_up_cooldown_seconds" {
-  default = "300"
+variable "target_tracking_metric_type" {
+  default = "ASGAverageCPUUtilization"
 }
 
-variable "scale_down_cooldown_seconds" {
-  default = "300"
+variable "ecs_cluster_cpu_reservation_target" {
+  default = "90.0"
 }
 
-variable "high_cpu_evaluation_periods" {
-  default = "2"
-}
-
-variable "high_cpu_period_seconds" {
-  default = "300"
-}
-
-variable "high_cpu_threshold_percent" {
-  default = "90"
-}
-
-variable "low_cpu_evaluation_periods" {
-  default = "2"
-}
-
-variable "low_cpu_period_seconds" {
-  default = "300"
-}
-
-variable "low_cpu_threshold_percent" {
-  default = "10"
-}
-
-variable "high_memory_evaluation_periods" {
-  default = "2"
-}
-
-variable "high_memory_period_seconds" {
-  default = "300"
-}
-
-variable "high_memory_threshold_percent" {
-  default = "90"
-}
-
-variable "low_memory_evaluation_periods" {
-  default = "2"
-}
-
-variable "low_memory_period_seconds" {
-  default = "300"
-}
-
-variable "low_memory_threshold_percent" {
-  default = "10"
+variable "ecs_cluster_memory_reservation_target" {
+  default = "90.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,6 @@ variable "memory_reservation_target_value" {
   default = "90.0"
 }
 
-variable "target_tracking_autoscaling_statistic" {
+variable "target_value_metric_statistic" {
   default = "Average"
 }


### PR DESCRIPTION
## Overview

This PR adds target tracking autoscaling support based on the same metrics we were previously tracking with CloudWatch alarms (`CPUReservation` and `MemoryReservation`).

Connects https://github.com/azavea/raster-foundry-platform/issues/617

## Testing Instructions

I created an instance of this module within a local Terraform project:

```hcl
module "container_service_cluster" {
  source = "github.com/azavea/terraform-aws-ecs-cluster?ref=375a076"

  root_block_device_type = "gp2"
  root_block_device_size = "32"

  lookup_latest_ami    = true
  vpc_id               = "${module.vpc.id}"
  instance_type        = "t2.nano"
  key_name             = "rocky"
  cloud_config_content = ""

  health_check_grace_period = "600"
  desired_capacity          = "5"
  min_size                  = "1"
  max_size                  = "10"

  enabled_metrics = [
    "GroupMinSize",
    "GroupMaxSize",
    "GroupDesiredCapacity",
    "GroupInServiceInstances",
    "GroupPendingInstances",
    "GroupStandbyInstances",
    "GroupTerminatingInstances",
    "GroupTotalInstances",
  ]

  subnet_ids = ["${module.vpc.private_subnet_ids}"]

  project     = "${var.project}"
  environment = "${var.environment}"
}
```

As you can see, I set a minimum size of `1`, but a desired capacity of `5`. When I instantiated the module yesterday, it took about 40 minutes until the first scale in operation took place. I tested increasing the desired capacity to `2` this morning, and the first scale in operation occurred after 5 minutes or so.

<img width="1737" alt="image" src="https://user-images.githubusercontent.com/1774125/53254762-09db4180-3692-11e9-98c4-1914002c753b.png">

I can attribute some of the latency yesterday to misconfigured security group rules, where the ECS agent couldn't communicate metrics to ECS for the first few minutes. Also, it's possible there needed to be a small amount of data collected in CloudWatch first, before scale in could kick in.