### PR TITLE
be able to set cluster name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 ## Variables
 
 - `cluster_name` - Name of the ECS Cluster, it is optional
-- `asg_name` - Name of the ASG name for ECS Cluster, it is optional
+- `autoscaling_group_name` - Name of the ASG name for ECS Cluster, it is optional
 - `sg_name` - Name of the Security Group name for ECS Cluster, it is optional
 - `iam_role_name` - Name of iam role for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 
 ## Variables
 
+- `cluster_name` - Name of the ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID. If `lookup_latest_ami` is `true`, this variable will be silently ignored.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 ## Variables
 
 - `cluster_name` - Name of the ECS Cluster, it is optional
+- `asg_name` - Name of the ASG name for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID. If `lookup_latest_ami` is `true`, this variable will be silently ignored.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 ## Variables
 
 - `cluster_name` - Name of the ECS Cluster, it is optional
-- `autoscaling_group_name` - Name of the ASG name for ECS Cluster, it is optional
-- `security_group_name` - Name of the Security Group name for ECS Cluster, it is optional
+- `autoscaling_group_name` - Name of the autoscaling group for ECS Cluster, it is optional
+- `security_group_name` - Name of the security group for ECS Cluster, it is optional
 - `ecs_for_ec2_service_role_name` - Name of iam role for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 
 - `cluster_name` - Name of the ECS Cluster, it is optional
 - `autoscaling_group_name` - Name of the ASG name for ECS Cluster, it is optional
-- `sg_name` - Name of the Security Group name for ECS Cluster, it is optional
+- `security_group_name` - Name of the Security Group name for ECS Cluster, it is optional
 - `iam_role_name` - Name of iam role for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 - `cluster_name` - Name of the ECS Cluster, it is optional
 - `autoscaling_group_name` - Name of the ASG name for ECS Cluster, it is optional
 - `security_group_name` - Name of the Security Group name for ECS Cluster, it is optional
-- `iam_role_name` - Name of iam role for ECS Cluster, it is optional
+- `ecs_for_ec2_service_role_name` - Name of iam role for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID. If `lookup_latest_ami` is `true`, this variable will be silently ignored.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 - `cluster_name` - Name of the ECS Cluster, it is optional
 - `asg_name` - Name of the ASG name for ECS Cluster, it is optional
 - `sg_name` - Name of the Security Group name for ECS Cluster, it is optional
+- `iam_role_name` - Name of iam role for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID. If `lookup_latest_ami` is `true`, this variable will be silently ignored.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ resource "aws_security_group_rule" "container_instance_https_egress" {
 
 - `cluster_name` - Name of the ECS Cluster, it is optional
 - `asg_name` - Name of the ASG name for ECS Cluster, it is optional
+- `sg_name` - Name of the Security Group name for ECS Cluster, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID. If `lookup_latest_ami` is `true`, this variable will be silently ignored.

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  cluster_name  = "ecs${title(var.environment)}Cluster"
-  asg_name      = "asg${title(var.environment)}ContainerInstance"
-  sg_name       = "sgContainerInstance"
-  iam_role_name = "${var.environment}ContainerInstanceProfile"
+  cluster_name           = "ecs${title(var.environment)}Cluster"
+  autoscaling_group_name = "asg${title(var.environment)}ContainerInstance"
+  sg_name                = "sgContainerInstance"
+  iam_role_name          = "${var.environment}ContainerInstanceProfile"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  cluster_name = "ecs${title(var.environment)}Cluster"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,4 @@
 locals {
   cluster_name = "ecs${title(var.environment)}Cluster"
+  asg_name     = "asg${title(var.environment)}ContainerInstance"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  cluster_name           = "ecs${title(var.environment)}Cluster"
-  autoscaling_group_name = "asg${title(var.environment)}ContainerInstance"
-  security_group_name    = "sgContainerInstance"
-  iam_role_name          = "${var.environment}ContainerInstanceProfile"
+  cluster_name                  = "ecs${title(var.environment)}Cluster"
+  autoscaling_group_name        = "asg${title(var.environment)}ContainerInstance"
+  security_group_name           = "sgContainerInstance"
+  ecs_for_ec2_service_role_name = "${var.environment}ContainerInstanceProfile"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
   cluster_name = "ecs${title(var.environment)}Cluster"
   asg_name     = "asg${title(var.environment)}ContainerInstance"
+  sg_name      = "sgContainerInstance"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  cluster_name = "ecs${title(var.environment)}Cluster"
-  asg_name     = "asg${title(var.environment)}ContainerInstance"
-  sg_name      = "sgContainerInstance"
+  cluster_name  = "ecs${title(var.environment)}Cluster"
+  asg_name      = "asg${title(var.environment)}ContainerInstance"
+  sg_name       = "sgContainerInstance"
+  iam_role_name = "${var.environment}ContainerInstanceProfile"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   cluster_name           = "ecs${title(var.environment)}Cluster"
   autoscaling_group_name = "asg${title(var.environment)}ContainerInstance"
-  sg_name                = "sgContainerInstance"
+  security_group_name    = "sgContainerInstance"
   iam_role_name          = "${var.environment}ContainerInstanceProfile"
 }

--- a/main.tf
+++ b/main.tf
@@ -185,7 +185,7 @@ resource "aws_autoscaling_group" "container_instance" {
     create_before_destroy = true
   }
 
-  name = "${coalesce(var.asg_name, local.asg_name)}"
+  name = "${coalesce(var.autoscaling_group_name, local.autoscaling_group_name)}"
 
   launch_template = {
     id      = "${aws_launch_template.container_instance.id}"

--- a/main.tf
+++ b/main.tf
@@ -185,7 +185,7 @@ resource "aws_autoscaling_group" "container_instance" {
     create_before_destroy = true
   }
 
-  name = "asg${title(var.environment)}ContainerInstance"
+  name = "${coalesce(var.asg_name, local.asg_name)}"
 
   launch_template = {
     id      = "${aws_launch_template.container_instance.id}"

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "container_instance" {
   vpc_id = "${var.vpc_id}"
 
   tags {
-    Name        = "${coalesce(var.sg_name, local.sg_name)}"
+    Name        = "${coalesce(var.security_group_name, local.security_group_name)}"
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
 }
 
 resource "aws_iam_role" "container_instance_ec2" {
-  name               = "${coalesce(var.iam_role_name, local.iam_role_name)}"
+  name               = "${coalesce(var.ecs_for_ec2_service_role_name, local.ecs_for_ec2_service_role_name)}"
   assume_role_policy = "${data.aws_iam_policy_document.container_instance_ec2_assume_role.json}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_autoscaling_group" "container_instance" {
 # ECS resources
 #
 resource "aws_ecs_cluster" "container_instance" {
-  name = "ecs${title(var.environment)}Cluster"
+  name = "${coalesce(var.cluster_name, local.cluster_name)}"
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "container_instance" {
   vpc_id = "${var.vpc_id}"
 
   tags {
-    Name        = "sgContainerInstance"
+    Name        = "${coalesce(var.sg_name, local.sg_name)}"
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
 }
 
 resource "aws_iam_role" "container_instance_ec2" {
-  name               = "${var.environment}ContainerInstanceProfile"
+  name               = "${coalesce(var.iam_role_name, local.iam_role_name)}"
   assume_role_policy = "${data.aws_iam_policy_document.container_instance_ec2_assume_role.json}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,10 @@ variable "environment" {
   default = "Unknown"
 }
 
+variable "cluster_name" {
+  default = ""
+}
+
 variable "vpc_id" {}
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,10 @@ variable "cluster_name" {
   default = ""
 }
 
+variable "asg_name" {
+  default = ""
+}
+
 variable "vpc_id" {}
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,10 @@ variable "asg_name" {
   default = ""
 }
 
+variable "sg_name" {
+  default = ""
+}
+
 variable "vpc_id" {}
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "cluster_name" {
   default = ""
 }
 
-variable "asg_name" {
+variable "autoscaling_group_name" {
   default = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,10 @@ variable "sg_name" {
   default = ""
 }
 
+variable "iam_role_name" {
+  default = ""
+}
+
 variable "vpc_id" {}
 
 variable "ami_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "autoscaling_group_name" {
   default = ""
 }
 
-variable "sg_name" {
+variable "security_group_name" {
   default = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "security_group_name" {
   default = ""
 }
 
-variable "iam_role_name" {
+variable "ecs_for_ec2_service_role_name" {
   default = ""
 }
 


### PR DESCRIPTION
by default the ECS name `ecs${title(var.environment)}Cluster` is working well with some conventions.
It will be nice to have ability to set it.

So are the sg_name, asg_name, and iam_role_name.

One of the major reason for setting the names, is the spinnaker deployment tool,
get some [naming convention](https://docs.armory.io/overview/naming-conventions/), the default naming will looks inconsistent when sipnnaker loading the aws infrastructure. 

![](https://ws2.sinaimg.cn/large/006tNc79gy1g25iky0apnj32400hoq7m.jpg)

So It will be nice to support this.


