### PR TITLE
Enable passing name for 'ecs_service_role'

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ We will reevaluate things when [Terraform 0.12](https://www.hashicorp.com/blog/t
 - `autoscaling_group_name` - Name of the autoscaling group for ECS Cluster, it is optional
 - `security_group_name` - Name of the security group for ECS Cluster, it is optional
 - `ecs_for_ec2_service_role_name` - Name of iam role for ECS Cluster, it is optional
+- `ecs_service_role_name` - Name of iam role for ECS Service, it is optional
 - `vpc_id` - ID of VPC meant to house cluster
 - `lookup_latest_ami` - lookup the latest Amazon-owned ECS AMI. If this variable is `true`, the latest ECS AMI will be used, even if `ami_id` is provided (default: `false`).
 - `ami_id` - Cluster instance Amazon Machine Image (AMI) ID. If `lookup_latest_ami` is `true`, this variable will be silently ignored.

--- a/locals.tf
+++ b/locals.tf
@@ -3,4 +3,5 @@ locals {
   autoscaling_group_name        = "asg${title(var.environment)}ContainerInstance"
   security_group_name           = "sgContainerInstance"
   ecs_for_ec2_service_role_name = "${var.environment}ContainerInstanceProfile"
+  ecs_service_role_name         = "ecs${title(var.environment)}ServiceRole"
 }

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "ecs_assume_role" {
 }
 
 resource "aws_iam_role" "ecs_service_role" {
-  name               = "ecs${title(var.environment)}ServiceRole"
+  name               = "${coalesce(var.ecs_service_role_name, local.ecs_service_role_name)}"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_assume_role.json}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,7 @@ variable "enabled_metrics" {
 variable "subnet_ids" {
   type = "list"
 }
+
+variable "ecs_service_role_name" {
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,10 @@ variable "ecs_for_ec2_service_role_name" {
   default = ""
 }
 
+variable "ecs_service_role_name" {
+  default = ""
+}
+
 variable "vpc_id" {}
 
 variable "ami_id" {
@@ -97,8 +101,4 @@ variable "enabled_metrics" {
 
 variable "subnet_ids" {
   type = "list"
-}
-
-variable "ecs_service_role_name" {
-  default = ""
 }


### PR DESCRIPTION
IAM role name `ecs${title(var.environment)}ServiceRole` works in most cases. 

But when you use the module to create multiple clusters in the same environment you'll notice that terraform tries to create the same role again and results in error. 

Therefore it'd be nice if we could set `ecs_service_role` as an input variable so that it could be overwritten in the above scenario. 

Also declaring the default in `locals` preserves the backward compatibility. 