### PR TITLE
allow ignore changes for some fields like desired_capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add CI support via CircleCI.
 - Add repository metadata support via Probot Settings.
 - Use top level `owners` attributes for `aws_ami` (requires AWS provider 2.0.0+).
+- Allow specified `ignore_changes` for autoacaling group.
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ We will reevaluate things when [Terraform 0.12](https://www.hashicorp.com/blog/t
 - `max_size` - Maximum number of EC2 instances in cluster (default: `1`)
 - `enabled_metrics` - A list of metrics to gather for the cluster
 - `subnet_ids` - A list of subnet IDs to launch cluster instances
+- `ignore_changes` - A list of fields that want be be ignore changes for autoscaling group. for example, "desired_capacity" (default: `[]`)  
 - `project` - Name of project this cluster is for (default: `Unknown`)
 - `environment` - Name of environment this cluster is targeting (default: `Unknown`)
 

--- a/main.tf
+++ b/main.tf
@@ -179,6 +179,7 @@ resource "aws_launch_template" "container_instance" {
 resource "aws_autoscaling_group" "container_instance" {
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = "${var.ignore_changes}"
   }
 
   name = "${coalesce(var.autoscaling_group_name, local.autoscaling_group_name)}"

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,8 @@ variable "enabled_metrics" {
 variable "subnet_ids" {
   type = "list"
 }
+
+variable "ignore_changes" {
+  type = "list"
+  default = []
+}


### PR DESCRIPTION
sometimes, in production, ECS instances will be auto scaling, and the `desired_capacity` already quite different.
it will be helpful to allow ignore changes like `desired_capacity`, 
which makes the apply won't affect the current nodes number, but only other fields. 
it is backward compatibility. 

example usage
```
module "container_service_cluster" {
  source = "azavea/terraform-aws-ecs-cluster"
  ...
  ignore_changes = ["desired_capacity"]
}
```