### PR TITLE
Add support for Terraform 0.12

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -5,3 +5,4 @@ locals {
   ecs_for_ec2_service_role_name = "${var.environment}ContainerInstanceProfile"
   ecs_service_role_name         = "ecs${title(var.environment)}ServiceRole"
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,32 @@
 output "id" {
-  value = "${aws_ecs_cluster.container_instance.id}"
+  value = aws_ecs_cluster.container_instance.id
 }
 
 output "name" {
-  value = "${aws_ecs_cluster.container_instance.name}"
+  value = aws_ecs_cluster.container_instance.name
 }
 
 output "container_instance_security_group_id" {
-  value = "${aws_security_group.container_instance.id}"
+  value = aws_security_group.container_instance.id
 }
 
 output "container_instance_ecs_for_ec2_service_role_name" {
-  value = "${aws_iam_role.container_instance_ec2.name}"
+  value = aws_iam_role.container_instance_ec2.name
 }
 
 output "ecs_service_role_name" {
-  value = "${aws_iam_role.ecs_service_role.name}"
+  value = aws_iam_role.ecs_service_role.name
 }
 
 output "container_instance_autoscaling_group_name" {
-  value = "${aws_autoscaling_group.container_instance.name}"
+  value = aws_autoscaling_group.container_instance.name
 }
 
 output "ecs_service_role_arn" {
-  value = "${aws_iam_role.ecs_service_role.arn}"
+  value = aws_iam_role.ecs_service_role.arn
 }
 
 output "container_instance_ecs_for_ec2_service_role_arn" {
-  value = "${aws_iam_role.container_instance_ec2.arn}"
+  value = aws_iam_role.container_instance_ec2.arn
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,8 @@ variable "ecs_service_role_name" {
   default = ""
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "ami_id" {
   default = "ami-6944c513"
@@ -60,9 +61,11 @@ variable "detailed_monitoring" {
   default = false
 }
 
-variable "key_name" {}
+variable "key_name" {
+}
 
-variable "cloud_config_content" {}
+variable "cloud_config_content" {
+}
 
 variable "cloud_config_content_type" {
   default = "text/cloud-config"
@@ -96,9 +99,10 @@ variable "enabled_metrics" {
     "GroupTotalInstances",
   ]
 
-  type = "list"
+  type = list(string)
 }
 
 variable "subnet_ids" {
-  type = "list"
+  type = list(string)
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Connects #54 

This changeset was suggested by terraform's `0.12upgrade` tool, as required by a project I'm currently upgrading from 0.11.11.

To test this, the project I'm currently upgrading is loading the most recent commit from this branch like below in the staging environment:
`source = "github.com/azavea/terraform-aws-ecs-cluster?ref=a5475bab0fdc1e6468803fa264b4abb004cb9563"`

Though this changeset has not been applied, `/scripts/infra plan` runs correctly without error, showing expected changes, nothing major related to this module